### PR TITLE
Get the sha1 from the file directly, not through its public URI

### DIFF
--- a/Classes/FusionObjects/HashedResourceUriImplementation.php
+++ b/Classes/FusionObjects/HashedResourceUriImplementation.php
@@ -2,23 +2,58 @@
 
 namespace CRON\NeosHashedAssets\FusionObjects;
 
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Package\Exception\UnknownPackageException;
+use Neos\Flow\Package\FlowPackageInterface;
+use Neos\Flow\Package\PackageManager;
+use Neos\Fusion\Exception;
 use Neos\Fusion\FusionObjects\ResourceUriImplementation;
 
 /**
  * A Fusion object that behaves the same as Neos.Fusion:ResourceUri
  * but appends '?<sha1>' to the URI, <sha1> being the SHA1 hash of the
  * resource file's content.
+ *
+ * Only fusion property "path" is supported, expected with the syntax "resource://<Package>/Public/..."
  */
 class HashedResourceUriImplementation extends ResourceUriImplementation
 {
+
+    /**
+     * @Flow\Inject
+     * @var PackageManager
+     */
+    protected $packageManager;
+
     public function evaluate()
     {
-        // get the URI that Neos.Fusion:ResourceUri returns
         $resourceUri = parent::evaluate();
 
-        // the URI can be used to create the SHA1 hash from the file content
-        $sha1 = sha1_file($resourceUri);
+        // append a sha1, if possible
+        $path = $this->fusionValue('path');
+        if (strpos($path, 'resource://') === 0) {
+            $matches = [];
+            if (preg_match('#^resource://([^/]+)(/Public/.*)#', $path, $matches) !== 1) {
+                throw new Exception(sprintf('The specified path "%s" does not point to a public resource.', $path), 1617009244);
+            }
+            $package = $matches[1];
+            $relativePath = $matches[2];
+            try {
+                $packagePath = $this->packageManager->getPackage($package)->getPackagePath();
+            } catch (UnknownPackageException $e) {
+                throw new Exception(sprintf('The specified path "%s" does not point to a valid package.', $path), 1617009246);
+            }
+            $filename = $packagePath . FlowPackageInterface::DIRECTORY_RESOURCES . $relativePath;
+            if (!is_readable($filename)) {
+                throw new Exception(sprintf('The specified path "%s" does not point to a readable filename.', $path), 1617009245);
+            }
 
-        return $resourceUri . ($sha1 ? '?' . $sha1 : '');
+            $sha1 = sha1_file($filename);
+            $resourceUri .= (strpos($resourceUri, '?') === false) ? '?' : '&';
+            $resourceUri .= $sha1;
+        }
+
+        return $resourceUri;
     }
+
 }

--- a/Resources/Private/Fusion/Prototypes/HashedResourceUri.fusion
+++ b/Resources/Private/Fusion/Prototypes/HashedResourceUri.fusion
@@ -1,20 +1,14 @@
 prototype(CRON.NeosHashedAssets:HashedResourceUri) < prototype(Neos.Fusion:Component) {
 
     path = null
-    package = null
-    resource = null
-    localize = true
 
     @cache {
         mode = 'cached'
         entryIdentifier {
             1 = ${props.path}
-            2 = ${props.package}
-            3 = ${props.resource}
-            4 = ${props.localize}
         }
         entryTags {
-
+            1 = ${props.path}
         }
     }
 

--- a/Resources/Private/Fusion/Prototypes/HashedResourceUri.fusion
+++ b/Resources/Private/Fusion/Prototypes/HashedResourceUri.fusion
@@ -9,6 +9,7 @@ prototype(CRON.NeosHashedAssets:HashedResourceUri) < prototype(Neos.Fusion:Compo
         }
         entryTags {
             1 = ${props.path}
+            2 = 'HashedResourceUri'
         }
     }
 


### PR DESCRIPTION
1. We should not try to fetch an "Public URI" to apply SHA1 to it, as it won't work:

a) if the URI is not reachable (i.e. in Monocle)
b) if PHP does not allow calling "external URIs" in its stream functions (i.e. with `open_basedir` restriction)

This should make it more robust, but also make it only work with "resources" from our own packages (which is what we intend anyway).

Also fix the URI if it already might contain a query parameter with "?" to use a "&" separator instead.

2. also add the "path" as a cache tag, which allows us to clear a particular cached entry if required.